### PR TITLE
Fix missing webmin-postgresql

### DIFF
--- a/plan/main
+++ b/plan/main
@@ -7,6 +7,6 @@ postgresql-9.4-postgis
 adminer			 /* Adminer - Replaces phpPgAdmin */
 lighttpd                 /* we use lighty to power adminer */
 php5-cgi                 /* needed for lighty cgi and adminer depend */
-php5-pgsql		 /* needed for adminer pg support 
+php5-pgsql		 /* needed for adminer pg support */
 
 webmin-postgresql        /* webmin is in base, give the user the option */


### PR DESCRIPTION
The webmin-postgresql wasn't included in resulting .iso because of a missing end comment mark.
